### PR TITLE
chore: Add TextController for API endpoints

### DIFF
--- a/src/main/java/com/example/demo/TextController.java
+++ b/src/main/java/com/example/demo/TextController.java
@@ -1,0 +1,19 @@
+package com.example.demo;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class TextController {
+
+    @GetMapping("/api/reverse")
+    public String reverse(@RequestParam String text) {
+        return new StringBuilder(text).reverse().toString();
+    }
+
+    @GetMapping("/api/disemvowel")
+    public String disemvowel(@RequestParam String text) {
+        return text.replaceAll("[aeiouAEIOU]", "");
+    }
+}


### PR DESCRIPTION
This pull request introduces a new Java file, `TextController.java`, in the `src/main/java/com/example/demo` directory. This controller provides two API endpoints: `api/reverse` and `api/disemvowel`. The `api/reverse` endpoint takes a string parameter and returns the reversed string, while the `api/disemvowel` endpoint takes a string parameter and returns the string with all vowels removed. 

Key changes:

* [`src/main/java/com/example/demo/TextController.java`](diffhunk://#diff-5b34694beef838f691b9aa6de8985ae2aac58073c835731fab62780433a230a1R1-R19): Added a new `TextController` class that includes two API endpoints, `api/reverse` and `api/disemvowel`. The `api/reverse` endpoint reverses a given string, and the `api/disemvowel` endpoint removes all vowels from a given string.